### PR TITLE
feat: StaticFiles 추가하여 /uploads 경로에서 이미지 서빙 가능하도록 설정

### DIFF
--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -26,23 +26,41 @@ def create_db_and_tables():
 # dependencies.py -> dependencies/io.py, db.py로 모듈화 하면 예쁠 듯듯
 # 팀원과 상의 해야할 듯
 import os
+import uuid
+import time
 from typing import Optional
-UPLOAD_DIR = "./uploads"
-if not os.path.exists(UPLOAD_DIR):
-    os.makedirs(UPLOAD_DIR)
+from pathlib import Path
+UPLOAD_DIR = Path("./uploads")
+ALLOWED_EXTENSIONS = {"jpg", "jpeg", "png", "gif"}
 
-async def save_UploadFile(file: UploadFile, filename: str) -> Optional[str]:
-    file_path = os.path.join(UPLOAD_DIR, filename)
+def create_upload_dir():
+    if not os.path.exists(UPLOAD_DIR):
+        os.makedirs(UPLOAD_DIR)
+
+def is_allowed_file(filename: str) -> bool:
+    return '.' in filename and filename.split('.')[-1].lower() in ALLOWED_EXTENSIONS
+
+def unique_filename(filename: str) -> str:
+    ext = filename.split('.')[-1]
+    return f"{int(time.time())}_{uuid.uuid4().hex}.{ext}"
+
+async def save_UploadFile(file: UploadFile) -> Optional[str]:
+    if not is_allowed_file(file.filename):
+        return None
+    
+    file_name = unique_filename(file.filename)
+    file_path = UPLOAD_DIR / file_name
     if os.path.exists(file_path):
         return None
+    
     with open(file_path, "wb") as file_object:
         data = await file.read()
         file_object.write(data)
-    return file_path
+    return file_name
 
-def delete_file(file_path: str) -> bool:
+def delete_file(file_name: str) -> bool:
+    file_path = UPLOAD_DIR / file_name
     if not os.path.exists(file_path):
         return False
-    
     os.remove(file_path)
     return True

--- a/app/handlers/product_handler.py
+++ b/app/handlers/product_handler.py
@@ -105,25 +105,8 @@ def update_product(product: ProductRequest = Body(...),
 def delete_product(product_id: int = Path(..., ge=0),
                    db: Session = Depends(get_db_session),
                    productService: ProductService = Depends()) -> None:
-    # !: Product 삭제 전에 Product와 연결되어 있는 테이블들에서도 삭제해줘야함..
-    # => sol 1. DELETE /products/{product_id}에서 각 테이블에 대한 DELETE API를 호출
-    # => sol 2. DB에서 CASCADE 설정 => 자동으로 연결된 테이블에서도 삭제
-    # 의논해봐야 할 듯.
-    productService.delete_all_product_images(db, product_id)
     productService.delete_product(db, product_id)
     return None
-
-# !: 업로드 된 image를 가져오기 위하여
-# GET /products/{product_id}/images{image_id} 이런 것도 필요할 듯
-# TODO: 
-@router.get("/{product_id}/image/{image_id}", status_code=200)
-def get_product_image(product_id: int = Path(..., ge=0),
-                      image_id: int = Path(..., ge=0),
-                      db: Session = Depends(get_db_session),
-                      productService: ProductService = Depends()
-) -> ProductImage:
-    # return productService.get_product_image(db, product_id, image_id)
-    raise NotImplementedError()
 
 @router.post("/{product_id}/image", status_code=200)
 async def upload_product_image(product_id: int = Path(..., ge=0),

--- a/app/services/product_service.py
+++ b/app/services/product_service.py
@@ -98,7 +98,7 @@ class ProductService:
         product = db.get(Product, product_id)
         if not product:
             raise HTTPException(status_code=404, detail="Product not found.")
-        file_path = await save_UploadFile(image, f"{product.id}_{image.filename}")
+        file_path = await save_UploadFile(image)
         if not file_path:
             raise HTTPException(status_code=400, detail="File already exists.")
         productImage = ProductImage(product_id=product.id, image_URI=file_path)
@@ -119,16 +119,20 @@ class ProductService:
         if not productImage:
             raise HTTPException(status_code=404, detail="ProductImage not found.")
         db.delete(productImage)
-        delete_file(productImage.image_URI)
-        db.commit()
-        return True
+        if delete_file(productImage.image_URI):
+            db.commit()
+        else:
+            db.rollback()
+            raise HTTPException(status_code=500, detail="Failed to delete file.")
     
-    def delete_all_product_images(self, db: Session,
-                                  product_id: int) -> None:
-        product = db.get(Product, product_id)
-        if not product:
-            raise HTTPException(status_code=404, detail="Product not found.")
-        for productImage in self.get_product_images(db, product_id):
-            db.delete(productImage)
-        db.commit()
-        return None
+    ### Decaprecated
+    # def delete_all_product_images(self, db: Session,
+    #                               product_id: int) -> None:
+    #     product = db.get(Product, product_id)
+    #     if not product:
+    #         raise HTTPException(status_code=404, detail="Product not found.")
+    #     for productImage in self.get_product_images(db, product_id):
+    #         db.delete(productImage)
+    #         delete_file(productImage.image_URI)
+    #     db.commit()
+    #     return None

--- a/main.py
+++ b/main.py
@@ -7,7 +7,7 @@ from fastapi import FastAPI, Depends, HTTPException, Request
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from sqlmodel import Session, select
-from app.dependencies import get_db_session, create_db_and_tables
+from app.dependencies import get_db_session, create_db_and_tables, create_upload_dir, UPLOAD_DIR
 from app.models.models import User, Product, Category, ProductImage, Likes, Comment, Purchase  # 모델들을 불러옵니다.
 from pydantic import BaseModel
 from app.handlers import (auth_handler,
@@ -21,6 +21,7 @@ app = FastAPI()
 @app.on_event("startup")
 def on_startup():
     create_db_and_tables()
+    create_upload_dir()
 
 app.include_router(auth_handler.router)
 app.include_router(chat_handlers.router)
@@ -29,7 +30,7 @@ app.include_router(product_handler.router)
 
 # 정적 파일 (CSS, JS, 이미지 등) 제공
 app.mount("/static", StaticFiles(directory="static"), name="static")
-
+app.mount("/uploads", StaticFiles(directory=UPLOAD_DIR), name="uploads")
 # HTML 템플릿 설정
 templates = Jinja2Templates(directory="templates")
 


### PR DESCRIPTION
- FastAPI의 StaticFiles를 사용하여 /uploads 경로를 정적 파일 제공 경로로 마운트
- 클라이언트가 /uploads/{파일이름} URL을 통해 직접 이미지 파일 접근 가능