### PR TITLE
refactor: Separate Comment handler & service, update /comment endpoints, and add authentication

### DIFF
--- a/app/handlers/comment_handlers.py
+++ b/app/handlers/comment_handlers.py
@@ -25,7 +25,7 @@ def get_comments(
 # 댓글 생성 (인증 필요)
 @router.post("/", status_code=201)
 def create_comment(
-    product_id: int, 
+    product_id: int = Body(...), 
     content: str = Body(..., description="댓글 내용"),
     current_user: User = Depends(get_current_user),
     session = Depends(get_db_session)

--- a/app/handlers/comment_handlers.py
+++ b/app/handlers/comment_handlers.py
@@ -1,54 +1,62 @@
 # app/handlers/comment_handler.py
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Body, Depends, HTTPException
 from sqlmodel import select
+from app.handlers.auth_handler import get_current_user
 from app.models.user_and_product_model import *
 from app.db import get_db_session
+from app.services.comment_service import CommentService
 
-router = APIRouter(
-    prefix="/products"
-)
+router = APIRouter(prefix="/products")
+comment_service = CommentService
 
 # 댓글 목록 조회
-# 임시로 limit 10으로 설정
+# limit 10으로 설정
+# 인증 불필요
 @router.get("/{product_id}/comments", status_code=200)
-def get_comments(product_id: int,limit: int=10, session=Depends(get_db_session)) -> RespComments:
-    if limit < 1 or limit > 10:
-        limit = 10
-    comments = session.exec(select(Comment).where(Comment.product_id == product_id).limit(limit)).all()
+def get_comments(
+    product_id: int,
+    limit: int=10, 
+    session=Depends(get_db_session)
+    ) -> RespComments:
+
+    comments = comment_service.get_comments(session, product_id, limit)
     return RespComments(comments=comments)
 
-# 댓글 생성
+# 댓글 생성 (인증 필요)
 @router.post("/{product_id}/comments", status_code=201)
-def create_comment(product_id: int,comment_data: ReqComment, 
-                session = Depends(get_db_session)) -> RespComments:
-    new_comment = Comment(product_id=product_id,
-                        user_id=comment_data.user_id,
-                        content=comment_data.content)
-    session.add(new_comment)
-    session.commit()
-    session.refresh(new_comment)
+def create_comment(
+    product_id: int, 
+    content: str = Body(..., description="댓글 내용"),
+    current_user: User = Depends(get_current_user),
+    session = Depends(get_db_session)
+    ) -> RespComments:
+    
+    new_comment = comment_service.create_comment(session, product_id, current_user.id, content)
     return RespComments(comments=[new_comment])
 
-# 댓글 수정
-@router.put("/{product_id}/comments/{comment_id}", status_code=200)
-def update_comment(product_id: int, comment_id: int,
-                comment_data : ReqComment, session = Depends(get_db_session)) -> RespComments:
-    comment = session.get(Comment, comment_id)
-    if not comment:
-        raise HTTPException(status_code=404, details="Comment not found")
-    comment.content = comment_data.content
-    session.commit()
-    session.refresh(comment)
-    return RespComments(comments=[comment])
+# (주의) product_id는 수정, 삭제에 사용되지 않지만 Path의 일관성을 위해
 
-# ! product_id 사용 안하는데 빼버릴까요?
-# 댓글 삭제
+# 댓글 수정 (인증 필요)
+@router.put("/{product_id}/comments/{comment_id}", status_code=200)
+def update_comment(
+    product_id: int, 
+    comment_id: int,
+    content: str = Body(..., description="수정할 댓글 내용"),
+    current_user: User = Depends(get_current_user),
+    session = Depends(get_db_session)
+    ) -> RespComments:
+    
+    updated_comment = comment_service.update_comment(session, comment_id, current_user.id, content)
+    return RespComments(comments=[updated_comment])
+
+
+# 댓글 삭제 (인증 필요)
 @router.delete("/{product_id}/comments/{comment_id}", status_code=200)
-def delete_comment(product_id: int, comment_id: int,
-                session = Depends(get_db_session)):
-    comment = session.get(Comment, comment_id)
-    if not comment:
-        raise HTTPException(status_code=404, detail="Comment not found")
-    session.delete(comment)
-    session.commit()
-    return {"message": "Comment deleted successfully"}
+def delete_comment(
+    product_id: int, 
+    comment_id: int,
+    current_user: User = Depends(get_current_user),
+    session = Depends(get_db_session)):
+    
+    result = comment_service.delete_comment(session, comment_id, current_user.id)
+    return result

--- a/app/models/user_and_product_model.py
+++ b/app/models/user_and_product_model.py
@@ -70,6 +70,7 @@ class Comment(SQLModel, table=True):
     product_id: int = Field(foreign_key="product.id")
     user_id: int = Field(foreign_key="user.id")
     content: str
+    last_modified: datetime = Field(default_factory=datetime.now)
 
     product: Product = Relationship(back_populates="comments")
     user: User = Relationship(back_populates="comments")
@@ -99,9 +100,6 @@ class ProductSortType(Enum):
     ACCURACY = 0
     LATEST = 1
 
-class ReqComment(BaseModel):
-    user_id: int
-    content: str
 
 class RespComments(BaseModel):
     comments : list[Comment]

--- a/app/services/comment_service.py
+++ b/app/services/comment_service.py
@@ -20,6 +20,7 @@ class CommentService:
         if limit < 1 or limit > 10:
             limit = 10
         comments = db.exec(select(Comment).where(Comment.product_id == product_id).limit(limit)).all()
+        return comments
     
     # 댓글 생성
     def create_comment(self, db: Session, product_id: int, user_id: int, content: str):
@@ -36,6 +37,7 @@ class CommentService:
 
         comment.content = content
         comment.last_modified = datetime.now()
+        db.commit()
         db.refresh(comment)
         return comment
     

--- a/app/services/comment_service.py
+++ b/app/services/comment_service.py
@@ -1,0 +1,50 @@
+from fastapi import HTTPException
+from app.models.user_and_product_model import *
+from sqlmodel import Session, select
+
+class CommentService:
+    # 댓글 ID로 댓글 조회
+    def get_comment_by_id(self, db: Session, comment_id: int):
+        comment = db.get(Comment, comment_id)
+        if not comment:
+            raise HTTPException(status_code=404, detail="Comment not found")
+        return comment
+    
+    # 댓글 작성자인지 확인
+    def check_comment_owner(self, comment: Comment, user_id: int):
+        if comment.user_id != user_id:
+            raise HTTPException(status_code=403, detail="Permission denied")
+    
+    # 특정 상품의 댓글 목록 조회
+    def get_comments(self, db: Session, product_id: int, limit: int = 10):
+        if limit < 1 or limit > 10:
+            limit = 10
+        comments = db.exec(select(Comment).where(Comment.product_id == product_id).limit(limit)).all()
+    
+    # 댓글 생성
+    def create_comment(self, db: Session, product_id: int, user_id: int, content: str):
+        new_comment = Comment(product_id=product_id, user_id=user_id, content=content)
+        db.add(new_comment)
+        db.commit()
+        db.refresh(new_comment)
+        return new_comment
+    
+    # 댓글 수정
+    def update_comment(self, db: Session, comment_id: int, user_id: int, content: str):
+        comment = self.get_comment_by_id(db, comment_id)
+        self.check_comment_owner(comment, user_id)
+
+        comment.content = content
+        comment.last_modified = datetime.now()
+        db.refresh(comment)
+        return comment
+    
+    # 댓글 삭제
+    def delete_comment(self, db: Session, comment_id: int, user_id: int):
+        comment = self.get_comment_by_id(db, comment_id)
+        self.check_comment_owner(comment, user_id)
+        
+        db.delete(comment)
+        db.commit()
+        return {"message": "Comment deleted successfully"}
+


### PR DESCRIPTION
## 변경 사항
### 1️⃣ **핸들러(Handler)와 서비스(Service) 로직 분리**
- `CommentHandler`에서 비즈니스 로직을 `CommentService`로 이동하여 코드 구조를 개선.

### 2️⃣ **RESTful API 원칙을 준수하도록 엔드포인트 변경**
| 변경 전 (Old) | 변경 후 (New) | 설명 |
|--------------|-------------|------|
| `GET /products/{product_id}/comments` | `GET /comments?product_id=xxx` | Query Parameter로 `product_id` 전달 |
| `POST /products/{product_id}/comments` | `POST /comments` | `product_id`는 Request Body에서 받음 |
| `PUT /products/{product_id}/comments/{comment_id}` | `PUT /comments/{comment_id}` | `product_id` 제거 (불필요) |
| `DELETE /products/{product_id}/comments/{comment_id}` | `DELETE /comments/{comment_id}` | `product_id` 제거 (불필요) |

### 3️⃣ **인증(Authentication) 추가**
- `POST`, `PUT`, `DELETE` 요청에서 `get_current_user`를 이용한 **인증 및 권한 검사** 추가.
- **본인 댓글만 수정/삭제 가능하도록 검증 로직 적용.**
